### PR TITLE
Refactor error handling and improve video duplication policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +160,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -384,6 +410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +475,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -957,10 +998,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "artistctl",
+ "assert_cmd",
  "clap",
  "cmn_rs",
+ "predicates",
  "serde_json",
  "tagctl",
+ "tempfile",
  "tracing",
 ]
 
@@ -981,11 +1025,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "artistctl",
+ "assert_cmd",
  "chrono",
  "clap",
  "cmn_rs",
  "dialoguer",
  "once_cell",
+ "predicates",
  "rand 0.10.0",
  "regex",
  "reqwest",
@@ -999,6 +1045,12 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1125,6 +1177,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1676,6 +1758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2113,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # cliplayer
 
-Hi!
+## Rust Tools
+
+### Overview
+
+- cmn_rs: 共通のユーティリティ
+- metadata:
+  - artist: アーティスト管理
+  - tag: タグ管理
+- music/musictl: 音楽管理
+- search: (開発中)
+  - engine: 検索エンジン
+  - index_fmt: 検索インデックスのフォーマット
+
+### Dependency
+
+musictl -> metadata
+search/engine -> metadata, index_fmt
+search/index_fmt -> metadata, musictl
+
+## TODO
+
+`/music`のrustツールである`musictl`に対して、テストを充実させたいです. 構想を練っています. 単体テストは少し書いていますが, 結合テスト, e2eテストも書きたいです. e2eは以下の構想ですが, 変えてもらって全く問題ないです. 依存の`metadata`にもテストが必要かもしれません. 構想が出来たら, ある程度詳細にmarkdownに出力してください.
+
+- e2e
+  - testcontainers-rs + mockserver(wiremock)
+  - endpointのconstを #[\cfg(test)]とか#[\cfg(features ...)]で切り替え
+  - constでなくlazy_static使う <- portが多分動的なのでenvぐらいから引っ張ってくる
+  - tempfileはもちもちもちもちもちろん使う

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -12,4 +12,7 @@ tagctl = { path = "./tag" }
 tracing = { workspace = true }
 
 [dev-dependencies]
+assert_cmd = "2.1.1"
+predicates = "3.1.3"
 serde_json = { workspace = true }
+tempfile = "3.26.0"

--- a/metadata/tests/cli_e2e.rs
+++ b/metadata/tests/cli_e2e.rs
@@ -1,0 +1,88 @@
+use assert_cmd::prelude::*;
+use std::io::Write;
+use std::process::Command;
+
+const LIVER_SNIPPET_JSON5: &str = r#"{
+  "LiverNamesSnippet": {
+    "prefix": "liver",
+    "body": ["placeholder"],
+    "description": "test snippet"
+  },
+  "keep": {
+    "x": 1
+  }
+}
+"#;
+
+const TAG_SNIPPET_JSON5: &str = r#"{
+  "VideoTagsSnippet": {
+    "prefix": "vtag",
+    "body": ["placeholder"],
+    "description": "test snippet"
+  },
+  "keep": {
+    "x": 1
+  }
+}
+"#;
+
+fn write_text_file(path: &std::path::Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+}
+
+#[test]
+fn test_metadata_artist_command_generates_outputs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let snippet_path = tmp.path().join("music.code-snippets");
+    write_text_file(&snippet_path, LIVER_SNIPPET_JSON5);
+
+    let mut cmd = Command::cargo_bin("metadata").unwrap();
+    cmd.arg("artist")
+        .arg("--output-dir")
+        .arg(out_dir.to_string_lossy().to_string())
+        .arg("--min-livers-search-index-file-name")
+        .arg("livers_search_index.min.json")
+        .arg("--min-channels-file-name")
+        .arg("channels.min.json")
+        .arg("--min-livers-file-name")
+        .arg("livers.min.json")
+        .arg("--min-official-channels-file-name")
+        .arg("official_channels.min.json")
+        .arg("--music-code-snippets-path")
+        .arg(snippet_path.to_string_lossy().to_string());
+
+    cmd.assert().success();
+
+    assert!(out_dir.join("livers_search_index.min.json").exists());
+    assert!(out_dir.join("channels.min.json").exists());
+    assert!(out_dir.join("livers.min.json").exists());
+    assert!(out_dir.join("official_channels.min.json").exists());
+
+    let snippet = std::fs::read_to_string(snippet_path).unwrap();
+    assert!(snippet.contains("LiverNamesSnippet"));
+    assert!(snippet.contains("\"${1|"));
+}
+
+#[test]
+fn test_metadata_tag_command_updates_snippet() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snippet_path = tmp.path().join("tags.code-snippets");
+    write_text_file(&snippet_path, TAG_SNIPPET_JSON5);
+
+    let mut cmd = Command::cargo_bin("metadata").unwrap();
+    cmd.arg("tag")
+        .arg("--code-snippets-path")
+        .arg(snippet_path.to_string_lossy().to_string());
+
+    cmd.assert().success();
+
+    let snippet = std::fs::read_to_string(snippet_path).unwrap();
+    assert!(snippet.contains("VideoTagsSnippet"));
+    assert!(snippet.contains("\"${1|"));
+}

--- a/music/Cargo.toml
+++ b/music/Cargo.toml
@@ -29,3 +29,5 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 artistctl = { path = "../metadata/artist", features = ["test-helpers"] }
+assert_cmd = "2.1.1"
+predicates = "3.1.3"

--- a/music/src/apply.rs
+++ b/music/src/apply.rs
@@ -1,8 +1,10 @@
 mod add;
+mod error;
 mod min_file;
 mod sync;
 mod update;
 
 pub use add::apply_add;
+pub use error::ApplyError;
 pub use sync::apply_sync;
 pub use update::apply_update;

--- a/music/src/apply/add.rs
+++ b/music/src/apply/add.rs
@@ -2,32 +2,63 @@ pub async fn apply_add(
     mut music_lib: crate::music_file::MusicLibrary,
     anonymous_videos: crate::model::AnonymousVideos,
     api_key: crate::fetcher::YouTubeApiKey,
+    duplicate_video_policy: crate::music_file::DuplicateVideoPolicy,
     min_clips_path: &std::path::Path,
     min_videos_path: &std::path::Path,
-) -> Result<(), ()> {
-    // api呼ぶ
+) -> Result<(), crate::apply::ApplyError> {
+    let youtube_api = crate::fetcher::YouTubeApi::new(api_key);
+
+    apply_add_with_fetcher(
+        &mut music_lib,
+        anonymous_videos,
+        |video_ids| youtube_api.run(video_ids),
+        duplicate_video_policy,
+        min_clips_path,
+        min_videos_path,
+    )
+    .await
+}
+
+async fn apply_add_with_fetcher<F, Fut>(
+    music_lib: &mut crate::music_file::MusicLibrary,
+    anonymous_videos: crate::model::AnonymousVideos,
+    fetch_video_info: F,
+    duplicate_video_policy: crate::music_file::DuplicateVideoPolicy,
+    min_clips_path: &std::path::Path,
+    min_videos_path: &std::path::Path,
+) -> Result<(), crate::apply::ApplyError>
+where
+    F: FnOnce(crate::model::VideoIds) -> Fut,
+    Fut: std::future::Future<
+            Output = Result<
+                crate::model::ApiVideoInfoList,
+                crate::fetcher::YouTubeApiError,
+            >,
+        >,
+{
     let video_ids = anonymous_videos.to_video_ids();
     tracing::info!("Fetching video info for new videos: {}", video_ids);
-    let api_video_info_list = crate::fetcher::YouTubeApi::new(api_key)
-        .run(video_ids)
-        .await
-        .map_err(|e| tracing::error!("Failed to call YouTube API: {e}"))?;
+    let api_video_info_list = fetch_video_info(video_ids).await?;
 
     let verified_videos = crate::model::VerifiedVideos::from_anonymous_video(
         anonymous_videos,
         api_video_info_list,
-    )
-    .map_err(|e| tracing::error!("Failed to verify videos: {e}"))?;
+    )?;
 
-    // 既存の音楽ファイルの情報に追加
-    music_lib.extend_videos(verified_videos);
+    music_lib.extend_videos(verified_videos, duplicate_video_policy)?;
 
-    // データベースを更新
-    music_lib
-        .save_month_files()
-        .map_err(|e| tracing::error!("Failed to save music month files: {e}"))?;
+    persist_add_outputs(music_lib, min_clips_path, min_videos_path)
+}
 
-    // minファイルを更新
-    super::min_file::save_min_files(music_lib, min_clips_path, min_videos_path)
-        .map_err(|e| tracing::error!("Failed to save min files: {e}"))
+fn persist_add_outputs(
+    music_lib: &crate::music_file::MusicLibrary,
+    min_clips_path: &std::path::Path,
+    min_videos_path: &std::path::Path,
+) -> Result<(), crate::apply::ApplyError> {
+    music_lib.save_month_files()?;
+
+    // `save_min_files` は所有権を取るため clone する。
+    // ここでは月ファイル保存後に min ファイル生成だけを行いたい。
+    super::min_file::save_min_files(music_lib.clone(), min_clips_path, min_videos_path)
+        .map_err(Into::into)
 }

--- a/music/src/apply/error.rs
+++ b/music/src/apply/error.rs
@@ -1,0 +1,13 @@
+#[derive(thiserror::Error, Debug)]
+pub enum ApplyError {
+    #[error("YouTube API request failed: {0}")]
+    YouTubeApi(#[from] crate::fetcher::YouTubeApiError),
+    #[error("Failed to verify video data: {0}")]
+    VerifyVideos(#[from] crate::model::VerifiedVideoErrors),
+    #[error("Music file operation failed: {0}")]
+    MusicFile(#[from] crate::music_file::MusicFileError),
+    #[error("Music file operations failed: {0}")]
+    MusicFiles(#[from] crate::music_file::MusicFileErrors),
+    #[error("Some files failed during sync:\n{0}")]
+    SyncPartialFailure(String),
+}

--- a/music/src/apply/sync.rs
+++ b/music/src/apply/sync.rs
@@ -4,34 +4,57 @@
 #[derive(Debug)]
 enum SyncError {
     Continue(std::path::PathBuf, String),
-    Fatal(String),
+    Fatal(crate::apply::ApplyError),
 }
 
 /// 音楽ライブラリのすべての月ファイルを順に YouTube API で
 /// 更新し、最終的に `min` ファイル群を出力する。
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(music_lib))]
 pub async fn apply_sync(
-    mut music_lib: crate::music_file::MusicLibrary,
+    music_lib: crate::music_file::MusicLibrary,
     api_key: crate::fetcher::YouTubeApiKey,
     min_clips_path: &std::path::Path,
     min_videos_path: &std::path::Path,
-) -> Result<(), ()> {
+) -> Result<(), crate::apply::ApplyError> {
     let youtube_api = crate::fetcher::YouTubeApi::new(api_key);
 
+    apply_sync_with_fetcher(
+        music_lib,
+        |video_ids| youtube_api.run(video_ids),
+        min_clips_path,
+        min_videos_path,
+    )
+    .await
+}
+
+async fn apply_sync_with_fetcher<F, Fut>(
+    mut music_lib: crate::music_file::MusicLibrary,
+    mut fetch_video_info: F,
+    min_clips_path: &std::path::Path,
+    min_videos_path: &std::path::Path,
+) -> Result<(), crate::apply::ApplyError>
+where
+    F: FnMut(crate::model::VideoIds) -> Fut,
+    Fut: std::future::Future<
+            Output = Result<
+                crate::model::ApiVideoInfoList,
+                crate::fetcher::YouTubeApiError,
+            >,
+        >,
+{
     let mut failed_files: Vec<String> = Vec::new();
 
     for music_file in music_lib.iter_files_mut() {
         let path_buf = music_file.get_path().to_path_buf();
         tracing::debug!("Syncing music file: {}", path_buf.display());
-        match sync_one_file(music_file, &youtube_api).await {
+        match sync_one_file(music_file, &mut fetch_video_info).await {
             Ok(()) => {}
             Err(SyncError::Continue(p, msg)) => {
                 failed_files.push(format!("{}: {}", p.display(), msg));
                 continue;
             }
-            Err(SyncError::Fatal(msg)) => {
-                tracing::error!("Fatal sync error: {msg}");
-                return Err(());
+            Err(SyncError::Fatal(e)) => {
+                return Err(e);
             }
         }
     }
@@ -40,15 +63,11 @@ pub async fn apply_sync(
         tracing::info!("All music files synced successfully.");
         // minファイルを更新
         super::min_file::save_min_files(music_lib, min_clips_path, min_videos_path)
-            .map_err(|e| {
-                tracing::error!("Failed to save min files: {e}");
-            })
+            .map_err(Into::into)
     } else {
-        tracing::error!(
-            "Some music files failed to sync:\n{}",
-            failed_files.join("\n")
-        );
-        Err(())
+        Err(crate::apply::ApplyError::SyncPartialFailure(
+            failed_files.join("\n"),
+        ))
     }
 }
 
@@ -56,24 +75,28 @@ pub async fn apply_sync(
 ///
 /// - `Ok(())`: 成功したとき
 /// - `SyncError`: 失敗したとき
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(youtube_api))]
-async fn sync_one_file(
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(fetch_video_info))]
+async fn sync_one_file<F, Fut>(
     music_file: &mut crate::music_file::MusicFile,
-    youtube_api: &crate::fetcher::YouTubeApi,
-) -> Result<(), SyncError> {
+    fetch_video_info: &mut F,
+) -> Result<(), SyncError>
+where
+    F: FnMut(crate::model::VideoIds) -> Fut,
+    Fut: std::future::Future<
+            Output = Result<
+                crate::model::ApiVideoInfoList,
+                crate::fetcher::YouTubeApiError,
+            >,
+        >,
+{
     let path_buf = music_file.get_path().to_path_buf();
     let video_ids = music_file.get_video_ids();
 
-    let api_video_info_list = youtube_api
-        .run(video_ids)
+    let api_video_info_list = fetch_video_info(video_ids)
         .await
         // youtube api呼べなかったときは, 別ファイルでfetchしても
         // 失敗する可能性が高いので, 即時リターンするように戻り値を与える
-        .map_err(|e| {
-            let msg = format!("Failed to call YouTube API: {e}");
-            tracing::error!("{msg}");
-            SyncError::Fatal(msg)
-        })?;
+        .map_err(|e| SyncError::Fatal(e.into()))?;
 
     let new_videos = music_file
         .clone()
@@ -96,6 +119,187 @@ async fn sync_one_file(
         tracing::error!("{msg}");
         SyncError::Continue(path_buf.clone(), msg)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MONTH_2024_01_JSON: &str = r#"[
+    {
+        "videoId": "11111111111",
+        "title": "sync test video 1",
+        "channelId": "UCivwPlOp0ojnMPZj5pNOPPA",
+        "publishedAt": "2024-01-01T01:01:01Z",
+        "syncedAt": "2025-01-01T01:01:01Z",
+        "duration": "PT1H0M0S",
+        "privacyStatus": "public",
+        "embeddable": true,
+        "videoTags": ["karaoke"],
+        "clips": [
+            {
+                "songTitle": "song-1",
+                "liverIds": ["riku-tazumi"],
+                "startTime": "PT1M0S",
+                "endTime": "PT2M0S",
+                "uuid": "11786ebd-4b42-428b-81f8-ecf791887326"
+            }
+        ]
+    }
+]
+"#;
+
+    const MONTH_2024_02_JSON: &str = r#"[
+    {
+        "videoId": "22222222222",
+        "title": "sync test video 2",
+        "channelId": "UC7_MFM9b8hp5kuTSpa8WyOQ",
+        "publishedAt": "2024-02-02T02:02:02Z",
+        "syncedAt": "2025-01-01T01:01:01Z",
+        "duration": "PT1H0M0S",
+        "privacyStatus": "public",
+        "embeddable": true,
+        "videoTags": ["karaoke"],
+        "clips": [
+            {
+                "songTitle": "song-2",
+                "liverIds": ["yugamin"],
+                "startTime": "PT2M0S",
+                "endTime": "PT3M0S",
+                "uuid": "3fc31423-b991-4c88-8de7-71d2ed9b50c5"
+            }
+        ]
+    }
+]
+"#;
+
+    fn write_month_file(root: &std::path::Path, year: usize, month: usize, json: &str) {
+        let path = root.join(format!("{year:04}/{month:02}.json"));
+        std::fs::create_dir_all(path.parent().expect("parent dir exists")).unwrap();
+        std::fs::write(path, json).unwrap();
+    }
+
+    fn build_music_library(root: &std::path::Path) -> crate::music_file::MusicLibrary {
+        crate::music_file::MusicLibrary::load(root).unwrap()
+    }
+
+    fn api_info_for_id(id: &crate::model::VideoId) -> crate::model::ApiVideoInfo {
+        use chrono::TimeZone;
+
+        let published_at = if *id == crate::model::VideoId::test_id_1() {
+            crate::model::VideoPublishedAt::self_1()
+        } else {
+            crate::model::VideoPublishedAt::self_2()
+        };
+
+        crate::model::ApiVideoInfoInitializer {
+            video_id: id.clone(),
+            title: format!("synced-{id}"),
+            channel_id: crate::model::ChannelId::test_id_1(),
+            published_at,
+            synced_at: chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+            duration: crate::model::Duration::from_secs_u16(3600),
+            privacy_status: crate::model::PrivacyStatus::Public,
+            embeddable: true,
+        }
+        .init()
+    }
+
+    #[tokio::test]
+    async fn test_apply_sync_with_fetcher_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write_month_file(root, 2024, 1, MONTH_2024_01_JSON);
+        write_month_file(root, 2024, 2, MONTH_2024_02_JSON);
+
+        let min_clips = root.join("clips.min.json");
+        let min_videos = root.join("videos.min.json");
+
+        let lib = build_music_library(root);
+        let res = apply_sync_with_fetcher(
+            lib,
+            |video_ids| async move {
+                let infos = video_ids
+                    .into_vec()
+                    .into_iter()
+                    .map(|id| api_info_for_id(&id))
+                    .collect::<Vec<_>>();
+                Ok(crate::model::ApiVideoInfoList::from_vec_ignore_duplicated(
+                    infos,
+                ))
+            },
+            &min_clips,
+            &min_videos,
+        )
+        .await;
+
+        assert!(res.is_ok());
+        assert!(min_clips.exists());
+        assert!(min_videos.exists());
+    }
+
+    #[tokio::test]
+    async fn test_apply_sync_with_fetcher_fatal_network_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write_month_file(root, 2024, 1, MONTH_2024_01_JSON);
+
+        let min_clips = root.join("clips.min.json");
+        let min_videos = root.join("videos.min.json");
+
+        let lib = build_music_library(root);
+        let res = apply_sync_with_fetcher(
+            lib,
+            |_video_ids| async {
+                Err(crate::fetcher::YouTubeApiError::NetworkError(
+                    "network down".to_string(),
+                ))
+            },
+            &min_clips,
+            &min_videos,
+        )
+        .await;
+
+        assert!(matches!(
+            res,
+            Err(crate::apply::ApplyError::YouTubeApi(
+                crate::fetcher::YouTubeApiError::NetworkError(_)
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_apply_sync_with_fetcher_partial_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write_month_file(root, 2024, 1, MONTH_2024_01_JSON);
+
+        let min_clips = root.join("clips.min.json");
+        let min_videos = root.join("videos.min.json");
+
+        let lib = build_music_library(root);
+        let res = apply_sync_with_fetcher(
+            lib,
+            |_video_ids| async {
+                Ok(crate::model::ApiVideoInfoList::from_vec_ignore_duplicated(
+                    Vec::new(),
+                ))
+            },
+            &min_clips,
+            &min_videos,
+        )
+        .await;
+
+        match res {
+            Err(crate::apply::ApplyError::SyncPartialFailure(message)) => {
+                assert!(message.contains("Failed to apply API info to videos"));
+            }
+            other => panic!("expected SyncPartialFailure, got {other:?}"),
+        }
+    }
 }
 
 // cloneやりすぎかもしれんけど一旦無視

--- a/music/src/apply/update.rs
+++ b/music/src/apply/update.rs
@@ -2,18 +2,16 @@
 ///
 /// # Returns
 /// - `Ok(())`: 正常に更新が適用された場合
-/// - `Err(())`: エラーが発生した場合。エラーは`tracing::error!`で出力済み
-// TODO 設計むずい. 一旦clippy黙らすが, 要再検討
-#[allow(clippy::result_unit_err)]
+/// - `Err(_)`: エラーが発生した場合
 pub fn apply_update(
     music_lib: crate::music_file::MusicLibrary,
     min_clips_path: &std::path::Path,
     min_videos_path: &std::path::Path,
-) -> Result<(), ()> {
+) -> Result<(), crate::apply::ApplyError> {
     // 楽曲情報をファイルから取得して, そのまま書き込む:
     // - minに書き込みが必要なため
     // - 既存の楽曲情報でもソートされていることを保証するため
 
     super::min_file::save_all(music_lib, min_clips_path, min_videos_path)
-        .map_err(|e| tracing::error!("Failed to save files: {e}"))
+        .map_err(Into::into)
 }

--- a/music/src/cli/parser.rs
+++ b/music/src/cli/parser.rs
@@ -80,6 +80,9 @@ pub(crate) struct AddApplyArgs {
     /// The key of YouTube Data v3 api to fetch data
     #[arg(short, long, env = "YOUTUBE_API_KEY", hide_env_values = true)]
     pub(crate) api_key: crate::fetcher::YouTubeApiKey,
+    /// If set, duplicate video IDs in existing month files are overwritten
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    pub(crate) allow_overwrite_existing_video: bool,
     /// Directory where the results will be written
     #[arg(long, value_name = "DIR", default_value_t = cli_default_vals::default_music_root_dir())]
     pub(crate) music_root_dir: String,

--- a/music/src/cli_exec_handler.rs
+++ b/music/src/cli_exec_handler.rs
@@ -1,14 +1,12 @@
 mod add;
+mod error;
 mod sync;
 mod update;
 mod util;
 
-// 将来的にここ定義して柔軟に色々エラーを扱いたいという気持ち
-// pub struct CliExecError {
-//     //
-// }
+pub use error::CliExecError;
 
-pub async fn cli_exec_handler(cli: crate::cli::Cli) -> Result<(), ()> {
+pub async fn cli_exec_handler(cli: crate::cli::Cli) -> Result<(), CliExecError> {
     match cli.command {
         crate::cli::Commands::Add(new_cmd) => add::handle_add(new_cmd).await,
         crate::cli::Commands::Update(update_cmd) => update::handle_update(update_cmd),

--- a/music/src/cli_exec_handler/add.rs
+++ b/music/src/cli_exec_handler/add.rs
@@ -1,4 +1,6 @@
-pub(super) async fn handle_add(cmd: crate::cli::parser::AddCommands) -> Result<(), ()> {
+pub(super) async fn handle_add(
+    cmd: crate::cli::parser::AddCommands,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::cli::parser::AddMode;
     match cmd.mode {
         AddMode::Apply(args) => handle_apply(args).await,
@@ -6,33 +8,40 @@ pub(super) async fn handle_add(cmd: crate::cli::parser::AddCommands) -> Result<(
     }
 }
 
-async fn handle_apply(args: crate::cli::parser::AddApplyArgs) -> Result<(), ()> {
+async fn handle_apply(
+    args: crate::cli::parser::AddApplyArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::music_file::MusicLibrary;
 
-    let music_lib = MusicLibrary::load(args.music_root_dir.as_ref())
-        .map_err(|e| tracing::error!("Failed to load music library: {e}"))?;
+    let music_lib = MusicLibrary::load(args.music_root_dir.as_ref())?;
 
     let input_files = args.input.into_file_paths();
-    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)
-        .map_err(|e| {
-            tracing::error!("{e}");
-        })?;
+    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)?;
+
+    let duplicate_video_policy = if args.allow_overwrite_existing_video {
+        crate::music_file::DuplicateVideoPolicy::Overwrite
+    } else {
+        crate::music_file::DuplicateVideoPolicy::Reject
+    };
 
     crate::apply::apply_add(
         music_lib,
         anonymous_videos,
         args.api_key,
+        duplicate_video_policy,
         args.min_clips_path.as_ref(),
         args.min_videos_path.as_ref(),
     )
     .await
+    .map_err(Into::into)
 }
 
-fn handle_validate(args: crate::cli::parser::AddValidateArgs) -> Result<(), ()> {
+fn handle_validate(
+    args: crate::cli::parser::AddValidateArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     let input_files = args.input.into_file_paths();
 
-    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)
-        .map_err(|e| tracing::error!("{e}"))?;
+    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)?;
 
     if args.markdown {
         println!("# Music Data Summary\n\n{}", anonymous_videos.to_markdown());

--- a/music/src/cli_exec_handler/error.rs
+++ b/music/src/cli_exec_handler/error.rs
@@ -1,0 +1,17 @@
+#[derive(thiserror::Error, Debug)]
+pub enum CliExecError {
+    #[error(transparent)]
+    Apply(#[from] crate::apply::ApplyError),
+    #[error(transparent)]
+    MusicFile(#[from] crate::music_file::MusicFileErrors),
+    #[error(transparent)]
+    AnonymousVideoValidation(#[from] crate::validate::AnonymousVideoValidateErrors),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Interactive prompt error: {0}")]
+    Dialog(#[from] dialoguer::Error),
+    #[error("{0}")]
+    Message(String),
+}

--- a/music/src/cli_exec_handler/sync.rs
+++ b/music/src/cli_exec_handler/sync.rs
@@ -1,10 +1,9 @@
 pub(super) async fn handle_sync(
     cmd: crate::cli::parser::SyncCommands,
-) -> Result<(), ()> {
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::music_file::MusicLibrary;
 
-    let music_lib = MusicLibrary::load(cmd.music_root_dir.as_ref())
-        .map_err(|e| tracing::error!("Failed to load music library: {e}"))?;
+    let music_lib = MusicLibrary::load(cmd.music_root_dir.as_ref())?;
 
     crate::apply::apply_sync(
         music_lib,
@@ -13,4 +12,5 @@ pub(super) async fn handle_sync(
         cmd.min_videos_path.as_ref(),
     )
     .await
+    .map_err(Into::into)
 }

--- a/music/src/cli_exec_handler/update.rs
+++ b/music/src/cli_exec_handler/update.rs
@@ -1,4 +1,6 @@
-pub(super) fn handle_update(cmd: crate::cli::parser::UpdateCommands) -> Result<(), ()> {
+pub(super) fn handle_update(
+    cmd: crate::cli::parser::UpdateCommands,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::cli::parser::UpdateMode;
     match cmd.mode {
         UpdateMode::Apply(args) => handle_apply(args),
@@ -6,20 +8,24 @@ pub(super) fn handle_update(cmd: crate::cli::parser::UpdateCommands) -> Result<(
     }
 }
 
-fn handle_apply(args: crate::cli::parser::UpdateApplyArgs) -> Result<(), ()> {
-    let music_lib = crate::music_file::MusicLibrary::load(args.music_root_dir.as_ref())
-        .map_err(|e| tracing::error!("Failed to load music library: {e}"))?;
+fn handle_apply(
+    args: crate::cli::parser::UpdateApplyArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
+    let music_lib =
+        crate::music_file::MusicLibrary::load(args.music_root_dir.as_ref())?;
     crate::apply::apply_update(
         music_lib,
         args.min_clips_path.as_ref(),
         args.min_videos_path.as_ref(),
     )
+    .map_err(Into::into)
 }
 
-fn handle_validate(args: crate::cli::parser::UpdateValidateArgs) -> Result<(), ()> {
+fn handle_validate(
+    args: crate::cli::parser::UpdateValidateArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     // 読み込めてエラーがなければ検証成功
     let _music_lib =
-        crate::music_file::MusicLibrary::load(args.music_root_dir.as_ref())
-            .map_err(|e| tracing::error!("Failed to validate music library: {e}"))?;
+        crate::music_file::MusicLibrary::load(args.music_root_dir.as_ref())?;
     Ok(())
 }

--- a/music/src/cli_exec_handler/util.rs
+++ b/music/src/cli_exec_handler/util.rs
@@ -1,4 +1,6 @@
-pub(super) fn handle_util(cmd: crate::cli::parser::UtilCommands) -> Result<(), ()> {
+pub(super) fn handle_util(
+    cmd: crate::cli::parser::UtilCommands,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::cli::parser::UtilMode;
     match cmd.mode {
         UtilMode::Find(args) => handle_find(args),
@@ -6,13 +8,14 @@ pub(super) fn handle_util(cmd: crate::cli::parser::UtilCommands) -> Result<(), (
     }
 }
 
-fn handle_find(args: crate::cli::parser::FindDuplicateIdsArgs) -> Result<(), ()> {
+fn handle_find(
+    args: crate::cli::parser::FindDuplicateIdsArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use crate::model::{VideoId, VideoIds};
     use crate::music_file::MusicLibrary;
     use std::collections::HashSet;
 
-    let music_lib = MusicLibrary::load(args.music_root_dir.as_ref())
-        .map_err(|e| tracing::error!("Failed to load music library: {e}"))?;
+    let music_lib = MusicLibrary::load(args.music_root_dir.as_ref())?;
 
     let video_ids_in_lib: HashSet<VideoId> =
         music_lib.get_video_ids().into_iter().collect();
@@ -37,50 +40,45 @@ fn handle_find(args: crate::cli::parser::FindDuplicateIdsArgs) -> Result<(), ()>
     Ok(())
 }
 
-fn handle_merge(args: crate::cli::parser::MergeFilesArgs) -> Result<(), ()> {
+fn handle_merge(
+    args: crate::cli::parser::MergeFilesArgs,
+) -> Result<(), crate::cli_exec_handler::CliExecError> {
     use std::path::PathBuf;
-    use tracing::error;
 
     let input_dir = args.input_dir.as_ref();
-    let input_files = collect_json_files_in_dir(input_dir).map_err(|e| {
-        error!(
-            "Failed to collect json files under {}: {}",
-            input_dir.display(),
-            e
-        )
-    })?;
+    let input_files = collect_json_files_in_dir(input_dir)?;
 
-    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)
-        .map_err(|e| error!("{e}"))?;
+    let anonymous_videos = crate::validate::try_load_anonymous_videos(&input_files)?;
 
     let output_file = PathBuf::from(args.output_dir).join(format!(
         "{}.json",
         chrono::Utc::now().format("%Y-%m-%d_%H-%M-%S")
     ));
 
-    let file = std::fs::File::create(&output_file).map_err(|e| {
-        error!(
-            "Failed to create output file {}: {}",
-            output_file.display(),
-            e
-        )
-    })?;
+    let file = std::fs::File::create(&output_file)?;
 
-    serde_json::to_writer_pretty(file, &anonymous_videos)
-        .map_err(|e| error!("Failed to write: {e}"))?;
+    serde_json::to_writer_pretty(file, &anonymous_videos)?;
 
+    if ask_for_removal_confirmation()? {
+        for file in input_files {
+            if let Err(e) = std::fs::remove_file(&file) {
+                tracing::warn!(
+                    "Failed to remove source file {}: {}",
+                    file.display(),
+                    e
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ask_for_removal_confirmation() -> Result<bool, crate::cli_exec_handler::CliExecError>
+{
     dialoguer::Confirm::new()
         .with_prompt("Do you want to remove the original files?")
         .interact()
-        .map_err(|e| error!("Failed to read user input: {e}"))?
-        .then(|| {
-            for file in input_files {
-                if let Err(e) = std::fs::remove_file(&file) {
-                    error!("Failed to remove file {}: {}", file.display(), e);
-                }
-            }
-        });
-    Ok(())
+        .map_err(Into::into)
 }
 
 /// 特定のディレクトリ以下の`*.json`ファイルのパスを集める
@@ -88,14 +86,11 @@ fn handle_merge(args: crate::cli::parser::MergeFilesArgs) -> Result<(), ()> {
 /// - 再帰的でない
 fn collect_json_files_in_dir(
     dir: &std::path::Path,
-) -> Result<Vec<std::path::PathBuf>, String> {
+) -> Result<Vec<std::path::PathBuf>, crate::cli_exec_handler::CliExecError> {
     let mut json_files = Vec::new();
 
-    for entry in
-        std::fs::read_dir(dir).map_err(|e| format!("Failed to read directory: {e}"))?
-    {
-        let entry =
-            entry.map_err(|e| format!("Failed to read directory entry: {e}"))?;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
         let path = entry.path();
         if path
             .extension()

--- a/music/src/fetcher/error.rs
+++ b/music/src/fetcher/error.rs
@@ -8,7 +8,7 @@
 
 /// YouTube API呼び出し時のエラー
 #[derive(Debug, thiserror::Error, Clone)]
-pub(crate) enum YouTubeApiError {
+pub enum YouTubeApiError {
     /// apiが不正/制限
     #[error("forbidden: {0}")]
     Forbidden(String),

--- a/music/src/fetcher/youtube.rs
+++ b/music/src/fetcher/youtube.rs
@@ -71,7 +71,10 @@ impl YouTubeApi {
                     Err(e) => {
                         retry_count += 1;
                         if retry_count >= network_cfg::MAX_RETRY {
-                            tracing::error!(error = ?e, "YouTube API fetch error after retries");
+                            tracing::error!(
+                                error = ?e,
+                                "YouTube API fetch error after retries"
+                            );
                             return Err(e);
                         }
                         tracing::warn!(

--- a/music/src/main.rs
+++ b/music/src/main.rs
@@ -6,11 +6,8 @@ async fn main() {
     let _tracing_guard = enable_tracing_log(&cli);
     tracing::debug!("Command line arguments: {:?}", cli);
 
-    if musictl::cli_exec_handler::cli_exec_handler(cli)
-        .await
-        .is_err()
-    {
-        // エラーの詳細はすでに tracing::error! で出力済み
+    if let Err(e) = musictl::cli_exec_handler::cli_exec_handler(cli).await {
+        tracing::error!("Command failed: {e}");
         std::process::exit(1);
     }
     tracing::info!("Command executed successfully.");

--- a/music/src/model.rs
+++ b/music/src/model.rs
@@ -21,7 +21,7 @@ pub(crate) use uuid::UuidVer4;
 pub(crate) use video::{
     AnonymousVideo, AnonymousVideos, ApiVideoInfo, ApiVideoInfoInitializer,
     ApiVideoInfoList, LocalVideoInfo, VerifiedVideo, VerifiedVideoError,
-    VerifiedVideos, VideoRecord,
+    VerifiedVideoErrors, VerifiedVideos, VideoRecord,
 };
 pub(crate) use video_id::{VideoId, VideoIds};
 pub(crate) use video_published_at::VideoPublishedAt;

--- a/music/src/model/video.rs
+++ b/music/src/model/video.rs
@@ -7,4 +7,6 @@ pub(crate) use record::{
     ApiVideoInfo, ApiVideoInfoInitializer, ApiVideoInfoList, LocalVideoInfo,
     VideoRecord,
 };
-pub(crate) use verified::{VerifiedVideo, VerifiedVideoError, VerifiedVideos};
+pub(crate) use verified::{
+    VerifiedVideo, VerifiedVideoError, VerifiedVideoErrors, VerifiedVideos,
+};

--- a/music/src/model/video/verified.rs
+++ b/music/src/model/video/verified.rs
@@ -2,6 +2,6 @@ mod error;
 mod video;
 mod videos;
 
-pub(crate) use error::VerifiedVideoError;
+pub(crate) use error::{VerifiedVideoError, VerifiedVideoErrors};
 pub(crate) use video::VerifiedVideo;
 pub(crate) use videos::VerifiedVideos;

--- a/music/src/model/video/verified/error.rs
+++ b/music/src/model/video/verified/error.rs
@@ -30,9 +30,11 @@ pub(crate) enum VerifiedVideoError {
 
 /// 複数の`VerifiedVideoError`をまとめたもの
 #[derive(Debug)]
-pub(crate) struct VerifiedVideoErrors {
+pub struct VerifiedVideoErrors {
     errs: Vec<VerifiedVideoError>,
 }
+
+impl std::error::Error for VerifiedVideoErrors {}
 
 impl std::fmt::Display for VerifiedVideoErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/music/src/model/video/verified/videos.rs
+++ b/music/src/model/video/verified/videos.rs
@@ -112,14 +112,28 @@ impl VerifiedVideos {
         }
     }
 
-    /// 動画を追加
+    /// 動画を追加する（重複は拒否）
     ///
-    /// 動画のvideo_idが重複していれば上書き
-    ///
-    /// # Returns
-    /// - `Some(動画)`: 追加前に同じvideo_idの動画が存在していた場合
-    /// - `None`: 新規追加の場合
+    /// # Errors
+    /// - すでに同一 `video_id` が存在する場合
     pub(crate) fn insert_video(
+        &mut self,
+        video: super::VerifiedVideo,
+    ) -> Result<(), crate::model::VideoId> {
+        use std::collections::hash_map::Entry;
+
+        let id = video.get_video_id().clone();
+        match self.inner.entry(id) {
+            Entry::Occupied(entry) => Err(entry.key().clone()),
+            Entry::Vacant(entry) => {
+                entry.insert(video);
+                Ok(())
+            }
+        }
+    }
+
+    /// 動画を追加する（重複時は上書き）
+    pub(crate) fn upsert_video(
         &mut self,
         video: super::VerifiedVideo,
     ) -> Option<super::VerifiedVideo> {

--- a/music/src/music_file.rs
+++ b/music/src/music_file.rs
@@ -7,5 +7,6 @@ pub(super) mod videos;
 
 pub(crate) use error::{MusicFileError, MusicFileErrors};
 pub(crate) use file::MusicFile;
+pub(crate) use videos::DuplicateVideoPolicy;
 
 pub use library::MusicLibrary;

--- a/music/src/music_file/error.rs
+++ b/music/src/music_file/error.rs
@@ -1,8 +1,10 @@
 /// `MusicFileError`をまとめたもの
 #[derive(Debug, Clone)]
-pub(crate) struct MusicFileErrors {
+pub struct MusicFileErrors {
     pub errs: Vec<MusicFileError>,
 }
+
+impl std::error::Error for MusicFileErrors {}
 
 /// 音楽情報のファイルに関するエラー
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
@@ -22,6 +24,23 @@ pub enum MusicFileError {
         ids: crate::model::VideoIds,
         year: usize,
         month: usize,
+        file_path: std::path::PathBuf,
+    },
+    /// 既存ファイルと同じ年月を持つ別ファイルが見つかった
+    #[error(
+        "Duplicate monthly file detected for ({year}/{month}): \
+        existing={existing_path}, duplicated={duplicated_path}"
+    )]
+    DuplicateYearMonthFile {
+        year: usize,
+        month: usize,
+        existing_path: std::path::PathBuf,
+        duplicated_path: std::path::PathBuf,
+    },
+    /// 同一ファイル内に重複した動画IDを追加しようとした
+    #[error("Duplicate video_id `{id}` found in file {file_path}")]
+    DuplicateVideoId {
+        id: crate::model::VideoId,
         file_path: std::path::PathBuf,
     },
     /// ファイルを開く際にエラーが発生

--- a/music/src/music_file/file.rs
+++ b/music/src/music_file/file.rs
@@ -68,22 +68,32 @@ impl MusicFile {
 
     /// 動画情報を追加
     ///
-    /// - 動画のvideo_idが重複してれば上書き
-    ///
     /// # Errors
     /// - 動画の投稿日の年/月がこのMusicFileの年/月と異なる場合
+    /// - 動画IDが重複している場合（重複ポリシーがRejectのとき）
     pub(super) fn push_video(
         &mut self,
         video: crate::model::VerifiedVideo,
+        duplicate_video_policy: super::videos::DuplicateVideoPolicy,
     ) -> Result<(), super::MusicFileError> {
-        self.videos.push_video(video).map_err(|id| {
-            super::MusicFileError::VideoPublishDateMismatch {
-                ids: id.into_ids(),
-                year: self.get_year(),
-                month: self.get_month(),
-                file_path: self.path.clone(),
-            }
-        })
+        self.videos
+            .push_video(video, duplicate_video_policy)
+            .map_err(|e| match e {
+                super::videos::PushVideoError::YearMonthMismatch(id) => {
+                    super::MusicFileError::VideoPublishDateMismatch {
+                        ids: id.into_ids(),
+                        year: self.get_year(),
+                        month: self.get_month(),
+                        file_path: self.path.clone(),
+                    }
+                }
+                super::videos::PushVideoError::DuplicateVideoId(id) => {
+                    super::MusicFileError::DuplicateVideoId {
+                        id,
+                        file_path: self.path.clone(),
+                    }
+                }
+            })
     }
 
     /// 動画情報を置き換え

--- a/music/src/music_file/library.rs
+++ b/music/src/music_file/library.rs
@@ -94,28 +94,45 @@ impl MusicLibrary {
     }
 
     /// 動画情報を一括で追加する
-    pub(crate) fn extend_videos(&mut self, videos: crate::model::VerifiedVideos) {
+    pub(crate) fn extend_videos(
+        &mut self,
+        videos: crate::model::VerifiedVideos,
+        duplicate_video_policy: crate::music_file::DuplicateVideoPolicy,
+    ) -> Result<(), crate::music_file::MusicFileErrors> {
+        let mut errs = Vec::new();
         for video in videos.into_sorted_vec() {
-            self.push_video(video);
+            if let Err(e) = self.push_video(video, duplicate_video_policy) {
+                errs.push(e);
+            }
+        }
+
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs.into())
         }
     }
 
     /// 楽曲情報を追加する
     ///
-    /// 動画idが重複していれば上書き
-    fn push_video(&mut self, video: crate::model::VerifiedVideo) {
+    fn push_video(
+        &mut self,
+        video: crate::model::VerifiedVideo,
+        duplicate_video_policy: crate::music_file::DuplicateVideoPolicy,
+    ) -> Result<(), crate::music_file::MusicFileError> {
         // 追加する動画の年月を特定して, 対応するファイルに追加
         let year_month = (video.get_year(), video.get_month());
         if let Some(music_file) = self.video_files.get_mut(&year_month) {
             // 対応する月ファイルが存在した時
-            music_file
-                .push_video(video)
-                // Safety: 対応する月ファイルが存在していることを確認済み
-                .expect("will match existing file");
+            music_file.push_video(video, duplicate_video_policy)
         } else {
             // 対応する月ファイルが存在しないとき. 新規作成して, そこに追加
             let music_file = super::MusicFile::from_video(video, &self.root_dir);
-            Self::insert_music_file(&mut self.video_files, music_file);
+            debug_assert!(
+                Self::insert_music_file(&mut self.video_files, music_file).is_none(),
+                "newly created month file must not conflict with existing keys"
+            );
+            Ok(())
         }
     }
 
@@ -162,10 +179,60 @@ impl MusicLibrary {
                 Err(_) => continue,
             };
             if entry.file_type().is_file() {
-                file_paths.push(entry.path().to_path_buf());
+                let path = entry.path();
+                if Self::is_monthly_music_file_path(dir, path) {
+                    file_paths.push(path.to_path_buf());
+                } else {
+                    tracing::trace!(
+                        "Skipped non-month music file while loading: {}",
+                        path.display()
+                    );
+                }
             }
         }
+        file_paths.sort_unstable();
         file_paths
+    }
+
+    /// ルート配下の `YYYY/MM.json` 形式に一致するか
+    fn is_monthly_music_file_path(
+        root: &std::path::Path,
+        path: &std::path::Path,
+    ) -> bool {
+        let rel = match path.strip_prefix(root) {
+            Ok(rel) => rel,
+            Err(_) => return false,
+        };
+
+        let mut components = rel.components();
+        let year = match components.next().and_then(|c| c.as_os_str().to_str()) {
+            Some(year) => year,
+            None => return false,
+        };
+        let month_file = match components.next().and_then(|c| c.as_os_str().to_str()) {
+            Some(month_file) => month_file,
+            None => return false,
+        };
+
+        if components.next().is_some() {
+            return false;
+        }
+
+        if year.len() != 4 || !year.chars().all(|c| c.is_ascii_digit()) {
+            return false;
+        }
+
+        if month_file.len() != 7 || !month_file.ends_with(".json") {
+            return false;
+        }
+
+        let month_str = &month_file[..2];
+        let month = match month_str.parse::<usize>() {
+            Ok(month) => month,
+            Err(_) => return false,
+        };
+
+        (1..=12).contains(&month)
     }
 
     /// ファイルパスごとにMusicFileをロードし、HashMapとエラーVecを返す
@@ -181,7 +248,23 @@ impl MusicLibrary {
         let mut errs: Vec<crate::music_file::MusicFileError> = Vec::new();
         for file_path in file_paths {
             match crate::music_file::MusicFile::load(file_path, dir) {
-                Ok(music_file) => Self::insert_music_file(&mut files, music_file),
+                Ok(music_file) => {
+                    let (year, month) = music_file.get_year_month();
+                    let duplicated_path = music_file.get_path().to_path_buf();
+
+                    if let Some(existing) =
+                        Self::insert_music_file(&mut files, music_file)
+                    {
+                        errs.push(
+                            crate::music_file::MusicFileError::DuplicateYearMonthFile {
+                                year,
+                                month,
+                                existing_path: existing.get_path().to_path_buf(),
+                                duplicated_path,
+                            },
+                        );
+                    }
+                }
                 Err(e) => errs.push(e),
             }
         }
@@ -192,14 +275,15 @@ impl MusicLibrary {
     ///
     /// `args`: key: `(year, month)`
     ///
-    /// - music_fileが重複していれば上書き
+    /// - 既存キーと重複している場合, 置き換え前の値を返す
     // TODO `self`を引数に受け取って`files`受け取らないようにしたい. しかし, `self`が使えない環境から呼び出されることもあるので困る
     fn insert_music_file(
         files: &mut std::collections::HashMap<(usize, usize), super::MusicFile>,
         music_file: super::MusicFile,
-    ) {
+    ) -> Option<super::MusicFile> {
         let year_month = music_file.get_year_month();
-        if let Some(_stale) = files.insert(year_month, music_file) {
+        let stale = files.insert(year_month, music_file);
+        if stale.is_some() {
             tracing::trace!(
                 "Music file for year/month `{}/{}` already exists, \
                 replacing stale file with new one.\n",
@@ -207,6 +291,7 @@ impl MusicLibrary {
                 year_month.1,
             );
         }
+        stale
     }
 
     /// 楽曲情報(単品)を全て保存

--- a/music/src/music_file/videos.rs
+++ b/music/src/music_file/videos.rs
@@ -6,6 +6,18 @@ pub(super) struct VideosSameYearMonth {
     videos: crate::model::VerifiedVideos,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuplicateVideoPolicy {
+    Reject,
+    Overwrite,
+}
+
+#[derive(Debug)]
+pub(super) enum PushVideoError {
+    YearMonthMismatch(crate::model::VideoId),
+    DuplicateVideoId(crate::model::VideoId),
+}
+
 impl VideosSameYearMonth {
     pub(super) fn get_year(&self) -> usize {
         self.year
@@ -44,25 +56,26 @@ impl VideosSameYearMonth {
 
     /// 動画情報を追加
     ///
-    /// - 動画のvideo_idが重複していれば上書き
-    ///
     /// # Errors
     /// - 動画の投稿日の年/月がこのVideosSameYearMonthの年/月と異なる場合
     pub(super) fn push_video(
         &mut self,
         video: crate::model::VerifiedVideo,
-    ) -> Result<(), crate::model::VideoId> {
-        self.ensure_same_year_month_from_video(&video)?;
-        if let Some(prev_video) = self.videos.insert_video(video) {
-            tracing::trace!(
-                "Video with id `{}` already exists, \
-                replacing stale video with new one.\n\
-                Stale video: {:?}",
-                prev_video.get_video_id(),
-                prev_video
-            );
+        duplicate_policy: DuplicateVideoPolicy,
+    ) -> Result<(), PushVideoError> {
+        self.ensure_same_year_month_from_video(&video)
+            .map_err(PushVideoError::YearMonthMismatch)?;
+
+        match duplicate_policy {
+            DuplicateVideoPolicy::Reject => self
+                .videos
+                .insert_video(video)
+                .map_err(PushVideoError::DuplicateVideoId),
+            DuplicateVideoPolicy::Overwrite => {
+                self.videos.upsert_video(video);
+                Ok(())
+            }
         }
-        Ok(())
     }
 
     /// 動画情報を全て置き換え

--- a/music/src/validate.rs
+++ b/music/src/validate.rs
@@ -1,7 +1,10 @@
 /// 複数の[`AnonymousVideoValidateError`]をまとめたもの
+#[derive(Debug)]
 pub struct AnonymousVideoValidateErrors {
     errs: Vec<AnonymousVideoValidateError>,
 }
+
+impl std::error::Error for AnonymousVideoValidateErrors {}
 
 /// anonymous videoの検証エラー
 #[derive(Debug)]

--- a/music/tests/cli_e2e.rs
+++ b/music/tests/cli_e2e.rs
@@ -1,0 +1,106 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::io::Write;
+use std::process::Command;
+
+const MONTHLY_FILE_JSON: &str = r#"[
+  {
+    "videoId": "cFc9Ywpk0QU",
+    "title": "Test Karaoke Stream",
+    "channelId": "UCivwPlOp0ojnMPZj5pNOPPA",
+    "publishedAt": "2026-01-19T13:23:27Z",
+    "syncedAt": "2026-04-22T01:57:28Z",
+    "duration": "PT1H0M0S",
+    "privacyStatus": "public",
+    "embeddable": true,
+    "videoTags": ["karaoke"],
+    "clips": [
+      {
+        "songTitle": "fuwafuwa time",
+        "liverIds": ["riku-tazumi"],
+        "startTime": "PT3M2S",
+        "endTime": "PT6M56S",
+        "uuid": "11786ebd-4b42-428b-81f8-ecf791887326"
+      }
+    ]
+  }
+]
+"#;
+
+const ANONYMOUS_INPUT_JSON: &str = r#"[
+  {
+    "videoId": "cFc9Ywpk0QU",
+    "videoTags": ["karaoke"],
+    "clips": [
+      {
+        "songTitle": "fuwafuwa time",
+        "liverIds": ["riku-tazumi"],
+        "startTime": "PT3M2S",
+        "endTime": "PT6M56S"
+      }
+    ]
+  }
+]
+"#;
+
+fn write_text_file(path: &std::path::Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+}
+
+#[test]
+fn test_add_validate_markdown_e2e() {
+    let tmp = tempfile::tempdir().unwrap();
+    let input_path = tmp.path().join("input/add.json");
+    write_text_file(&input_path, ANONYMOUS_INPUT_JSON);
+
+    let mut cmd = Command::cargo_bin("musictl").unwrap();
+    cmd.arg("add")
+        .arg("validate")
+        .arg("--input")
+        .arg(input_path.to_string_lossy().to_string())
+        .arg("--markdown");
+
+    cmd.assert()
+        .success()
+        .stdout(contains("# Music Data Summary"));
+}
+
+#[test]
+fn test_update_validate_e2e() {
+    let tmp = tempfile::tempdir().unwrap();
+    let music_root = tmp.path().join("music");
+    let month_path = music_root.join("2026/01.json");
+    write_text_file(&month_path, MONTHLY_FILE_JSON);
+
+    let mut cmd = Command::cargo_bin("musictl").unwrap();
+    cmd.arg("update")
+        .arg("validate")
+        .arg("--music-root-dir")
+        .arg(music_root.to_string_lossy().to_string());
+
+    cmd.assert().success();
+}
+
+#[test]
+fn test_util_find_duplicate_id_e2e() {
+    let tmp = tempfile::tempdir().unwrap();
+    let music_root = tmp.path().join("music");
+    let month_path = music_root.join("2026/01.json");
+    write_text_file(&month_path, MONTHLY_FILE_JSON);
+
+    let mut cmd = Command::cargo_bin("musictl").unwrap();
+    cmd.arg("util")
+        .arg("find")
+        .arg("--ids")
+        .arg("cFc9Ywpk0QU")
+        .arg("--music-root-dir")
+        .arg(music_root.to_string_lossy().to_string());
+
+    cmd.assert()
+        .success()
+        .stdout(contains("Duplicate video IDs found"));
+}


### PR DESCRIPTION
- Updated `apply_update` function to return a specific error type instead of a unit type.
- Added `allow_overwrite_existing_video` argument to `AddApplyArgs` for controlling video ID duplication behavior.
- Introduced `CliExecError` for better error management across CLI execution handlers.
- Enhanced `handle_add`, `handle_sync`, `handle_update`, and `handle_util` functions to utilize the new error type.
- Implemented duplicate video handling in `push_video` and `insert_video` methods, allowing for rejection or overwriting of duplicates.
- Added comprehensive error handling in music file operations, including duplicate year/month file detection.
- Created end-to-end tests for validating add and update commands, ensuring proper functionality of new features.